### PR TITLE
Add /character adjust command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  pull_request_target:
+    branches: [ "master" ]
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ Yes, we're saving the most important info for the end, after most people have al
 
 ### Milestones to private beta
 
-- [ ] Vampire character stats adjustment
-- [ ] Ghoul character stats adjustment
-- [ ] Mortal character stats adjustment
 - [ ] Specialties assignment
 - [ ] Specialties display
 - [ ] Specialties removal
+- [x] ~~*Vampire character stats adjustment*~~
+- [x] ~~*Ghoul character stats adjustment*~~
+- [x] ~~*Mortal character stats adjustment*~~
 - [x] ~~*User error messages*~~
 - [x] ~~*Character deletion*~~
 - [x] ~~*Basic (numeric) rolls*~~

--- a/bot.py
+++ b/bot.py
@@ -104,3 +104,13 @@ class BotchBot(discord.Bot):
             case _:
                 # TODO: Error reporter
                 raise err
+
+    def cmd_mention(
+        self,
+        name: str,
+        type: type[discord.ApplicationCommand] = discord.ApplicationCommand,
+    ) -> str | None:
+        """Shorthand for get_application_command(...).mention."""
+        if command := self.get_application_command(name, type=type):
+            return command.mention  # type: ignore
+        return None

--- a/botchcord/character/__init__.py
+++ b/botchcord/character/__init__.py
@@ -1,7 +1,7 @@
 """Character commands interface."""
 
-from botchcord.character import traits
+from botchcord.character import adjust, traits
 from botchcord.character.delete import delete
 from botchcord.character.display import display
 
-__all__ = ("delete", "display", "traits")
+__all__ = ("adjust", "delete", "display", "traits")

--- a/botchcord/character/__init__.py
+++ b/botchcord/character/__init__.py
@@ -1,6 +1,7 @@
 """Character commands interface."""
 
-from botchcord.character import adjust, traits
+from botchcord.character import traits
+from botchcord.character.adjust import adjust
 from botchcord.character.delete import delete
 from botchcord.character.display import display
 

--- a/botchcord/character/adjust.py
+++ b/botchcord/character/adjust.py
@@ -160,8 +160,9 @@ class Adjuster(ABC):
                 return i, btn
         raise ValueError(f"No button with ID {custom_id}")
 
+    @abstractmethod
     def _update_buttons(self):
-        pass
+        """Update button states."""
 
     @abstractmethod
     async def callback(self, interaction: discord.Interaction):

--- a/botchcord/character/adjust.py
+++ b/botchcord/character/adjust.py
@@ -1,0 +1,292 @@
+"""Character adjustment menus."""
+
+from abc import ABC, abstractmethod
+from collections import Counter
+
+import discord
+from discord import ButtonStyle
+from discord.ui import Button, Select, View
+
+import bot
+import botchcord.settings
+from botchcord.character.display import DisplayField, build_embed
+from botchcord.haven import haven
+from core.characters import Character, Damage, Tracker
+from core.characters.wod import Vampire
+
+__all__ = (
+    "Adjuster",
+    "BloodAdjuster",
+    "GroundingAdjuster",
+    "HealthAdjuster",
+    "Toggler",
+    "WillpowerAdjuster",
+)
+
+
+@haven()
+async def adjust(ctx: bot.AppCtx, character: Character):
+    """Present the adjuster views."""
+    toggler = Toggler(ctx, character)
+    await toggler.display()
+
+
+class Toggler(View):
+    """A view that toggles between subviews."""
+
+    def __init__(self, ctx: bot.AppCtx, char: Character):
+        super().__init__(timeout=180)
+        self.ctx = ctx
+        self.character = char
+        self.adjusters: list["Adjuster"] = []
+
+        self.selector = Select(placeholder="Select a stat to adjust")
+        self.selector.callback = self.select_adjuster
+        self.add_item(self.selector)
+
+        self.add_adjuster("Adjust: Health", HealthAdjuster)
+        self.add_adjuster("Adjust: Willpower", WillpowerAdjuster)
+        self.add_adjuster(f"Adjust: {char.grounding.path}", GroundingAdjuster)
+
+        if self.character.has_blood_pool:
+            self.add_adjuster("Adjust: Blood Pool", BloodAdjuster)
+
+    def _populate_menu(self, adjuster: "Adjuster"):
+        """Populate the menu."""
+        for btn in self.children[1:]:
+            self.remove_item(btn)
+        for btn in adjuster.buttons:
+            self.add_item(btn)
+
+    async def select_adjuster(self, interaction: discord.Interaction):
+        """Select the indicated subview."""
+        selected = self.selector.values[0]
+        idx = next(i for i, o in enumerate(self.selector.options) if o.label == selected)
+        new_adjuster = self.adjusters[idx]
+        self._populate_menu(new_adjuster)
+
+        # Mark the correct one as selected
+        for opt in self.selector.options:
+            opt.default = opt.label == selected
+
+        await interaction.response.edit_message(view=self)
+
+    def add_adjuster(self, label: str, adjuster_cls: type["Adjuster"]):
+        """Add a subview behind a select menu option."""
+        adjuster = adjuster_cls(self, self.character)
+        if not self.adjusters:
+            self._populate_menu(adjuster)
+            default = True
+        else:
+            default = False
+
+        self.adjusters.append(adjuster)
+        self.selector.add_option(label=label, default=default)
+
+    async def update(self, interaction: discord.Interaction):
+        """Update the character display and the view."""
+        use_emojis = await botchcord.settings.use_emojis(self.ctx)
+        await self.ctx.edit(embed=self._embed(use_emojis))
+        await interaction.response.edit_message(view=self)
+        await self.character.save()
+
+    async def display(self):
+        """Display the character stats adjuster."""
+        use_emojis = await botchcord.settings.use_emojis(self.ctx)
+        await self.ctx.respond(embed=self._embed(use_emojis))
+        await self.ctx.respond(view=self, ephemeral=True)
+
+    def _embed(self, use_emojis: bool) -> discord.Embed:
+        """The character display embed."""
+        fields = [
+            DisplayField.HEALTH,
+            DisplayField.WILLPOWER,
+            DisplayField.GROUNDING,
+        ]
+        if self.character.has_blood_pool:
+            fields.append(DisplayField.BLOOD_POOL)
+        return build_embed(self.ctx.bot, self.character, use_emojis, fields=tuple(fields))
+
+    async def on_timeout(self):
+        """Remove the controls and prompt user to run the command again."""
+        cmd = self.ctx.bot.cmd_mention("character adjust")
+        if self.message is not None:
+            await self.message.edit(
+                content=f"Adjustments timed out. Please run {cmd} again.",
+                view=None,
+            )
+
+
+class Adjuster(ABC):
+    """Base class for adjuster "subviews"."""
+
+    def __init__(self, container: Toggler, char: Character):
+        self.container = container
+        self.character = char
+        self.buttons: list[Button] = []
+        self._populate()
+        self._update_buttons()
+
+    @abstractmethod
+    def _populate(self):
+        """Override to populate the view."""
+
+    def add_item(self, btn: Button):
+        """Add a button."""
+        self.buttons.append(btn)
+
+    def add_row(
+        self,
+        row: int,
+        label: str,
+        dec_color=ButtonStyle.success,
+        inc_color=ButtonStyle.danger,
+    ):
+        """Adds an adjuster row."""
+        btn = Button(emoji="➖", style=dec_color, row=row)
+        btn.callback = self.callback
+        self.add_item(btn)
+        btn = Button(label=label, style=ButtonStyle.secondary, row=row, disabled=True)
+        btn.callback = self.callback
+        self.add_item(btn)
+        btn = Button(emoji="➕", style=inc_color, row=row)
+        btn.callback = self.callback
+        self.add_item(btn)
+
+    def get_button(self, custom_id: str | None) -> tuple[int, Button]:
+        """Get a button by ID."""
+        for i, btn in enumerate(self.buttons):
+            if btn.custom_id == custom_id:
+                return i, btn
+        raise ValueError(f"No button with ID {custom_id}")
+
+    def _update_buttons(self):
+        pass
+
+    @abstractmethod
+    async def callback(self, interaction: discord.Interaction):
+        """Perform the adjustment and inform the container."""
+        self._update_buttons()
+        await self.container.update(interaction)
+
+
+class HealthAdjuster(Adjuster):
+    """Adjust character health."""
+
+    def _populate(self):
+        for i, label in enumerate(["Bashing", "Lethal", "Aggravated"]):
+            self.add_row(i + 1, label)
+
+    def _update_buttons(self):
+        c = Counter(list(self.character.health))
+
+        # Bashing: 0, 2
+        self.buttons[0].disabled = c[Damage.BASHING] == 0
+        self.buttons[2].disabled = c[Damage.NONE] == 0
+
+        # Lethal: 3, 5
+        self.buttons[3].disabled = c[Damage.LETHAL] == 0
+        self.buttons[5].disabled = (c[Damage.NONE] + c[Damage.BASHING]) == 0
+
+        # Aggravated: 6, 8
+        self.buttons[6].disabled = c[Damage.AGGRAVATED] == 0
+        self.buttons[8].disabled = (c[Damage.NONE] + c[Damage.BASHING] + c[Damage.LETHAL]) == 0
+
+    async def callback(self, interaction: discord.Interaction):
+        i, btn = self.get_button(interaction.custom_id)
+        match btn.row:
+            case 1:
+                severity = Damage.BASHING
+            case 2:
+                severity = Damage.LETHAL
+            case 3:
+                severity = Damage.AGGRAVATED
+            case _:
+                raise ValueError("Health adjuster: Unexpected row")
+
+        # Buttons are in a grid, with the left column being decrement
+        # and the right being increment
+        if i in (0, 3, 6):
+            self.character.decrement_damage(Tracker.HEALTH, severity)
+        else:
+            self.character.increment_damage(Tracker.HEALTH, severity)
+
+        await super().callback(interaction)
+
+
+class WillpowerAdjuster(Adjuster):
+    """Adjust character willpower."""
+
+    def _populate(self):
+        self.add_row(1, "Temporary")
+        self.add_row(2, "Permanent")
+
+    def _update_buttons(self):
+        c = Counter(list(self.character.willpower))
+
+        self.buttons[0].disabled = c[Damage.BASHING] == 0
+        self.buttons[2].disabled = c[Damage.NONE] == 0
+        self.buttons[3].disabled = len(self.character.willpower) <= 1
+        self.buttons[5].disabled = len(self.character.willpower) >= 10
+
+    async def callback(self, interaction: discord.Interaction):
+        i, _ = self.get_button(interaction.custom_id)
+        match i:
+            # Temporary willpower
+            case 0:
+                self.character.decrement_damage(Tracker.WILLPOWER, Damage.BASHING)
+            case 2:
+                self.character.increment_damage(Tracker.WILLPOWER, Damage.BASHING)
+            # Permanent willpower
+            case 3:
+                self.character.willpower = self.character.willpower[1:]
+            case 5:
+                self.character.willpower = Damage.NONE + self.character.willpower
+
+        await super().callback(interaction)
+
+
+class GroundingAdjuster(Adjuster):
+    """Adjust character grounding (path/humanity)."""
+
+    def _populate(self):
+        self.add_row(1, self.character.grounding.path)
+        for btn in self.buttons:
+            btn.callback = self.callback
+
+    def _update_buttons(self):
+        self.buttons[0].disabled = self.character.grounding.rating == 0
+        self.buttons[2].disabled = self.character.grounding.rating == 10
+
+    async def callback(self, interaction: discord.Interaction):
+        i, _ = self.get_button(interaction.custom_id)
+        if i == 0:
+            self.character.grounding.decrement()
+        else:
+            self.character.grounding.increment()
+
+        await super().callback(interaction)
+
+
+class BloodAdjuster(Adjuster):
+    """Adjust character blood pool. This might be expandable to adjusting
+    special attributes--BP, Rage, Pillars, etc."""
+
+    character: Vampire
+
+    def _populate(self):
+        self.add_row(1, "Blood Pool", dec_color=ButtonStyle.danger, inc_color=ButtonStyle.success)
+
+    def _update_buttons(self):
+        self.buttons[0].disabled = self.character.blood_pool == 0
+        self.buttons[2].disabled = self.character.blood_pool == self.character.max_bp
+
+    async def callback(self, interaction: discord.Interaction):
+        i, _ = self.get_button(interaction.custom_id)
+
+        if i == 0:
+            self.character.reduce_blood(1)
+        else:
+            self.character.add_blood(1)
+
+        await super().callback(interaction)

--- a/botchcord/character/adjust.py
+++ b/botchcord/character/adjust.py
@@ -239,9 +239,11 @@ class WillpowerAdjuster(Adjuster):
                 self.character.increment_damage(Tracker.WILLPOWER, Damage.BASHING)
             # Permanent willpower
             case 3:
-                self.character.willpower = self.character.willpower[1:]
+                if len(self.character.willpower) > 1:
+                    self.character.willpower = self.character.willpower[1:]
             case 5:
-                self.character.willpower = Damage.NONE + self.character.willpower
+                if len(self.character.willpower) < 10:
+                    self.character.willpower = Damage.NONE + self.character.willpower
 
         await super().callback(interaction)
 

--- a/core/characters/__init__.py
+++ b/core/characters/__init__.py
@@ -8,6 +8,7 @@ from core.characters.base import (
     GameLine,
     Grounding,
     Splat,
+    Tracker,
     Trait,
 )
 
@@ -19,5 +20,6 @@ __all__ = (
     "GameLine",
     "Grounding",
     "Splat",
+    "Tracker",
     "Trait",
 )

--- a/core/characters/wod/vampire.py
+++ b/core/characters/wod/vampire.py
@@ -1,5 +1,7 @@
 """WoD vampire characters."""
 
+from pydantic import Field
+
 from core.characters.base import GameLine, Splat
 from core.characters.wod.mortal import Mortal
 
@@ -12,4 +14,12 @@ class Vampire(Mortal):
 
     generation: int
     max_bp: int
-    blood_pool: int
+    blood_pool: int = Field(ge=0)
+
+    def add_blood(self, count: int):
+        """Add blood, to a maximum of max_bp."""
+        self.blood_pool = min(self.max_bp, self.blood_pool + count)
+
+    def reduce_blood(self, count: int):
+        """Reduce blood, to a minimum of 0."""
+        self.blood_pool = max(0, self.blood_pool - count)

--- a/interface/wod/characters.py
+++ b/interface/wod/characters.py
@@ -27,6 +27,12 @@ class CharactersCog(Cog, name="General character commands"):
         """Delete a character."""
         await botchcord.character.delete(ctx, character)
 
+    @character.command()
+    @options.character("The character to adjust")
+    async def adjust(self, ctx: AppCtx, character: str):
+        """Adjust character stats."""
+        await botchcord.character.adjust(ctx, character)
+
 
 def setup(bot: BotchBot):
     """Add the cog to the bot."""

--- a/tests/bcord/test_char_adjust.py
+++ b/tests/bcord/test_char_adjust.py
@@ -1,0 +1,260 @@
+"""Character adjuster tests."""
+
+from typing import cast
+from unittest.mock import AsyncMock, call, patch
+
+import pytest
+from discord.ui import Select
+
+from bot import AppCtx, BotchBot
+from botchcord.character.adjust import (
+    Adjuster,
+    BloodAdjuster,
+    GroundingAdjuster,
+    HealthAdjuster,
+    Toggler,
+    WillpowerAdjuster,
+)
+from core.characters import Character, GameLine, Splat
+from core.characters.wod import Vampire
+from tests.characters import gen_char
+
+
+@pytest.fixture(autouse=True)
+def mock_char_save():
+    with patch("core.characters.Character.save") as mocked:
+        yield mocked
+
+
+@pytest.fixture(autouse=True)
+def mock_toggler_embed():
+    with patch("botchcord.character.adjust.build_embed") as mocked:
+        yield mocked
+
+
+@pytest.fixture(params=[Splat.MORTAL, Splat.VAMPIRE])
+def char(request) -> Character:
+    return gen_char(GameLine.WOD, request.param, name="Nadea Theron")
+
+
+@pytest.fixture
+def vamp() -> Vampire:
+    return gen_char(
+        GameLine.WOD,
+        Splat.VAMPIRE,
+        Vampire,
+        generation=13,
+        max_bp=10,
+        blood_pool=5,
+        virtues=[],
+    )
+
+
+@pytest.fixture
+def ctx() -> AppCtx:
+    bot = BotchBot()
+    inter = AsyncMock()
+    return AppCtx(bot, inter)
+
+
+@pytest.fixture
+async def toggler(ctx: AppCtx, vamp: Vampire) -> Toggler:
+    with patch("bot.AppCtx.edit", new_callable=AsyncMock):
+        toggler = Toggler(ctx, vamp)
+        return toggler
+
+
+# These tests have to be async due to Views grabbing the running loop
+
+
+async def test_init(toggler: Toggler):
+    select = cast(Select, toggler.children[0])
+    assert select.options[0].default
+
+    names = ("Health", "Willpower", toggler.character.grounding.path)
+    for i, name in enumerate(names):
+        assert select.options[i].label == f"Adjust: {name}"
+
+    if toggler.character.has_blood_pool:
+        assert select.options[-1].label == "Adjust: Blood Pool"
+
+    for i, btn in enumerate(toggler.adjusters[0].buttons):
+        assert toggler.children[i + 1] == btn
+
+
+# "idx" is the button index
+
+
+@pytest.mark.parametrize(
+    "idx,expected",
+    [
+        (0, "..//XX*"),
+        (2, "////XX*"),
+        (3, "..///X*"),
+        (5, "///XXX*"),
+        (6, "..///XX"),
+        (8, "///XX**"),
+    ],
+)
+async def test_health_adjuster(idx: int, expected: str, char: Character):
+    char.health = ".///XX*"
+    toggler = AsyncMock()
+    adjuster = HealthAdjuster(toggler, char)
+
+    inter = AsyncMock()
+    inter.custom_id = adjuster.buttons[idx].custom_id
+
+    await adjuster.callback(inter)
+    assert char.health == expected
+
+    toggler.update.assert_called_once_with(inter)
+
+
+@pytest.mark.parametrize(
+    "idx,count,expected",
+    [
+        (0, 1, "....//"),
+        (0, 2, "...../"),
+        (0, 3, "......"),
+        (0, 4, "......"),
+        (2, 1, "..////"),
+        (2, 2, "./////"),
+        (2, 3, "//////"),
+        (2, 4, "//////"),
+    ],
+)
+async def test_willpower_adjuster(
+    idx: int,
+    count: int,
+    expected: str,
+    toggler: Toggler,
+):
+    toggler.character.willpower = "...///"
+    adjuster = toggler.adjusters[1]
+
+    inter = AsyncMock()
+    inter.custom_id = adjuster.buttons[idx].custom_id
+
+    for _ in range(count):
+        await adjuster.callback(inter)
+    assert toggler.character.willpower == expected
+
+    assert toggler.ctx.edit.await_count == count
+    assert inter.response.edit_message.await_count == count
+    inter.response.edit_message.assert_has_awaits([call(view=toggler)] * count)
+    assert toggler.character.save.await_count == count
+
+
+@pytest.mark.parametrize(
+    "idx,count,expected",
+    [
+        (0, 1, 6),
+        (0, 2, 5),
+        (0, 3, 4),
+        (0, 4, 3),
+        (0, 5, 2),
+        (0, 6, 1),
+        (0, 7, 0),
+        (0, 8, 0),
+        (2, 1, 8),
+        (2, 2, 9),
+        (2, 3, 10),
+        (2, 4, 10),
+    ],
+)
+async def test_grounding_adjuster(idx: int, count: int, expected: int, toggler: Toggler):
+    assert toggler.character.grounding.rating == 7
+
+    adjuster = toggler.adjusters[2]
+
+    inter = AsyncMock()
+    inter.custom_id = adjuster.buttons[idx].custom_id
+
+    for _ in range(count):
+        await adjuster.callback(inter)
+    assert toggler.character.grounding.rating == expected
+
+    assert toggler.ctx.edit.await_count == count
+    assert inter.response.edit_message.await_count == count
+    inter.response.edit_message.assert_has_awaits([call(view=toggler)] * count)
+    assert toggler.character.save.await_count == count
+
+
+@pytest.mark.parametrize(
+    "idx,count,expected",
+    [
+        (0, 1, 4),
+        (0, 2, 3),
+        (0, 3, 2),
+        (0, 4, 1),
+        (0, 5, 0),
+        (0, 6, 0),
+        (2, 1, 6),
+        (2, 2, 7),
+        (2, 3, 8),
+        (2, 4, 9),
+        (2, 5, 10),
+        (2, 6, 10),
+    ],
+)
+# @patch("botchcord.character.adjust.Toggler._embed")
+async def test_blood_pool_adjuster(idx: int, count: int, expected: int, ctx: AppCtx, vamp: Vampire):
+    toggler = Toggler(ctx, vamp)
+    adjuster = toggler.adjusters[3]
+    assert isinstance(adjuster, BloodAdjuster)
+
+    inter = AsyncMock()
+    inter.custom_id = adjuster.buttons[idx].custom_id
+
+    for _ in range(count):
+        await adjuster.callback(inter)
+    assert vamp.blood_pool == expected
+
+    assert toggler.ctx.edit.await_count == count
+    assert inter.response.edit_message.await_count == count
+    inter.response.edit_message.assert_has_awaits([call(view=toggler)] * count)
+    assert toggler.character.save.await_count == count
+
+
+@pytest.mark.parametrize(
+    "cls,track,expected",
+    [
+        (HealthAdjuster, "....", {0: True, 2: False, 3: True, 5: False, 6: True, 8: False}),
+        (HealthAdjuster, "./X*", {0: False, 2: False, 3: False, 5: False, 6: False, 8: False}),
+        (HealthAdjuster, "//X*", {0: False, 2: True, 3: False, 5: False, 6: False, 8: False}),
+        (HealthAdjuster, "XXX*", {0: True, 2: True, 3: False, 5: True, 6: False, 8: False}),
+        (HealthAdjuster, "****", {0: True, 2: True, 3: True, 5: True, 6: False, 8: True}),
+        (WillpowerAdjuster, "...", {0: True, 2: False, 3: False}),
+        (WillpowerAdjuster, "../", {0: False, 2: False}),
+        (WillpowerAdjuster, "///", {0: False, 2: True}),
+        (WillpowerAdjuster, ".", {3: True}),
+        (WillpowerAdjuster, "..........", {5: True}),
+        (GroundingAdjuster, 5, {0: False, 2: False}),
+        (GroundingAdjuster, 0, {0: True, 2: False}),
+        (GroundingAdjuster, 10, {0: False, 2: True}),
+        (BloodAdjuster, 5, {0: False, 2: False}),
+        (BloodAdjuster, 0, {0: True, 2: False}),
+        (BloodAdjuster, 10, {0: False, 2: True}),
+    ],
+)
+def test_adjuster_button_states(
+    vamp: Vampire,
+    cls: type[Adjuster],
+    track: str | int,
+    expected: dict[int, bool],
+):
+    toggler = AsyncMock()
+    if cls is HealthAdjuster:
+        vamp.health = cast(str, track)
+    elif cls is WillpowerAdjuster:
+        vamp.willpower = cast(str, track)
+    elif cls is GroundingAdjuster:
+        vamp.grounding.rating = cast(int, track)
+    elif cls is BloodAdjuster:
+        vamp.blood_pool = cast(int, track)
+    else:
+        raise ValueError(f"Unexpected adjuster: {cls}")
+    adjuster = cls(toggler, vamp)
+
+    for idx, state in expected.items():
+        assert adjuster.buttons[idx].disabled == state

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,7 +1,7 @@
 """Bot instance tests."""
 
 from unittest import mock
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, PropertyMock, patch
 
 import pytest
 from discord import ApplicationCommandInvokeError, NotFound
@@ -90,3 +90,23 @@ async def test_not_found_ignored(bot: BotchBot, ctx: AppCtx):
     err = ApplicationCommandInvokeError(NotFound(MagicMock(), None))
     await bot.on_application_command_error(ctx, err)
     ctx.send_error.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "cmd,exists",
+    [
+        ("roll", True),
+        ("blep", False),
+    ],
+)
+@patch("bot.BotchBot.get_application_command")
+def test_cmd_mention(mock_get_cmd: Mock, bot: BotchBot, cmd: str, exists: bool):
+    # We can't use the real function, so let's just test our logic as we slave
+    # over high code coverage.
+    mock_get_cmd.return_value = Mock() if exists else None
+
+    mention = bot.cmd_mention(cmd)
+    if exists:
+        assert mention is not None
+    else:
+        assert mention is None


### PR DESCRIPTION
Adds a unified, menu-based `/character adjust` command that works for multiple splats. This will need expansion in the future (example: allow to change entire path, not just the current rating), but it's a great start.

* Closes #7
* Closes #8 
* Closes #9