### PR TITLE
Command refactor

### DIFF
--- a/src/botchcord/macro/create.py
+++ b/src/botchcord/macro/create.py
@@ -68,7 +68,7 @@ def create_macro(
         name=name,
         pool=rpp.pool,
         keys=rpk.pool,
-        difficulty=diff,
+        target=diff,
         rote=rote,
         hunt=False,
         comment=comment,

--- a/src/botchcord/macro/display.py
+++ b/src/botchcord/macro/display.py
@@ -49,7 +49,7 @@ def create_macro_entry(macro: Macro) -> str:
     lines = [
         f"### {macro.name}",
         f"**Pool:** {m(macro.pool_str)}",
-        f"**{target}:** {macro.difficulty}",
+        f"**{target}:** {macro.target}",
     ]
     if is_cofd:
         lines.append(f"**Rote:** {'Yes' if macro.rote else 'No'}")

--- a/src/botchcord/mroll.py
+++ b/src/botchcord/mroll.py
@@ -11,15 +11,15 @@ from core.characters import Character
 async def mroll(
     ctx: bot.AppCtx,
     macro_name: str,
-    diff_override: int | None,
+    target_override: int | None,
+    use_wp: bool,
+    rote_override: bool,
     comment_override: str | None,
     character: str | None,
-    use_wp=False,
-    rote_override=False,
 ):
     """Perform a macro roll.
 
-    The user can override the default difficulty with diff_override,
+    The user can override the default difficulty with target_override,
     and the default comment with comment_override."""
     haven = Haven(ctx, GAME_LINE, None, character, filter=lambda c: has_macro(c, macro_name))
 
@@ -27,12 +27,11 @@ async def mroll(
     macro = char.find_macro(macro_name)
     assert macro is not None  # Guaranteed
 
-    difficulty = diff_override or macro.target
+    difficulty = target_override or macro.target
     comment = comment_override or macro.comment
     rote = rote_override or macro.rote
 
     try:
-        print(difficulty)
         await botchcord.roll.roll(ctx, macro.key_str, difficulty, None, comment, char, use_wp, rote)
     except errors.RollError:
         await ctx.send_error(

--- a/src/botchcord/mroll.py
+++ b/src/botchcord/mroll.py
@@ -27,7 +27,7 @@ async def mroll(
     macro = char.find_macro(macro_name)
     assert macro is not None  # Guaranteed
 
-    difficulty = diff_override or macro.difficulty
+    difficulty = diff_override or macro.target
     comment = comment_override or macro.comment
     rote = rote_override or macro.rote
 

--- a/src/botchcord/mroll.py
+++ b/src/botchcord/mroll.py
@@ -32,7 +32,7 @@ async def mroll(
     rote = rote_override or macro.rote
 
     try:
-        await botchcord.roll.roll(ctx, macro.key_str, difficulty, None, comment, char, use_wp, rote)
+        await botchcord.roll.roll(ctx, macro.key_str, difficulty, None, use_wp, rote, comment, char)
     except errors.RollError:
         await ctx.send_error(
             "Error",

--- a/src/botchcord/roll.py
+++ b/src/botchcord/roll.py
@@ -40,12 +40,12 @@ def add_wp(pool: str) -> str:
 async def roll(
     ctx: bot.AppCtx,
     pool: str,
-    difficulty: int,
+    target: int,
     specialties: Optional[str],
+    wp: bool,
+    rote: bool,
     comment: Optional[str],
     character: Optional[str | Character],
-    wp=False,
-    rote=False,
 ):
     """Perform and display the specified roll. The roll is saved to the database."""
     if wp:
@@ -63,7 +63,7 @@ async def roll(
             raise errors.RollError(f"No characters able to roll `{pool}`.")
 
     rp.parse()
-    roll = Roll.from_parser(rp, ctx.guild.id, ctx.user.id, difficulty, GAME_LINE, rote).roll()
+    roll = Roll.from_parser(rp, ctx.guild.id, ctx.user.id, target, GAME_LINE, rote).roll()
 
     extra_specs = []
     if specialties:

--- a/src/core/characters/base.py
+++ b/src/core/characters/base.py
@@ -100,7 +100,7 @@ class Macro(BaseModel):
     name: str = Field(max_length=20)
     pool: list[str | int]
     keys: list[str | int]
-    difficulty: int = Field(ge=2, le=10)
+    target: int = Field(ge=2, le=10)
     rote: bool
     hunt: bool
     comment: Optional[str]

--- a/src/interface/cofd/basic.py
+++ b/src/interface/cofd/basic.py
@@ -19,6 +19,11 @@ class BasicCog(Cog, name="Basic CofD Commands"):
 
     @slash_command()
     @option("pool", description="The dice pool. May be a number or trait + attribute equation")
+    @option(
+        "use_wp",
+        description="Use WP on the roll. Can also add + WP to your pool",
+        default=False,
+    )
     @option("again", description="The number at which dice explode", choices=[10, 9, 8], default=10)
     @option(
         "specialty",
@@ -32,25 +37,20 @@ class BasicCog(Cog, name="Basic CofD Commands"):
         required=False,
         max_length=300,
     )
-    @option(
-        "use_wp",
-        description="Use WP on the roll. Can also add + WP to your pool",
-        default=False,
-    )
     @options.character("[Optional] The character performing the roll")
     async def roll(
         self,
         ctx: AppCtx,
         pool: str,
+        use_wp: bool,
         again: int,
         rote: bool,
         specialty: str,
         comment: str,
-        use_wp: bool,
         character: str,
     ):
         """Roll the dice! If you have a character, you can supply traits ("Strength + Brawl")."""
-        await botchcord.roll.roll(ctx, pool, again, specialty, comment, character, use_wp, rote)
+        await botchcord.roll.roll(ctx, pool, again, specialty, use_wp, rote, comment, character)
 
     @slash_command()
     async def chance(self, ctx: AppCtx):

--- a/src/interface/cofd/macros.py
+++ b/src/interface/cofd/macros.py
@@ -63,12 +63,12 @@ class MacrosCog(Cog, name="CofD macro commands"):
         required=False,
     )
     @option("rote", description="Override the Rote quality", default=False)
-    @option("comment", description="Override the default comment", required=False)
     @option(
         "use_wp",
         description="Override the macro to use WP",
         default=False,
     )
+    @option("comment", description="Override the default comment", required=False)
     @options.character("The character performing the roll")
     async def mroll(
         self,
@@ -76,12 +76,12 @@ class MacrosCog(Cog, name="CofD macro commands"):
         name: str,
         again: int,
         rote: bool,
-        comment: str,
         use_wp: bool,
+        comment: str,
         character: str,
     ):
         """Roll using a macro."""
-        await botchcord.mroll(ctx, name, again, comment, character, use_wp, rote)
+        await botchcord.mroll(ctx, name, again, use_wp, rote, comment, character)
 
 
 def setup(bot: BotchBot):

--- a/src/interface/wod/basic.py
+++ b/src/interface/wod/basic.py
@@ -21,6 +21,11 @@ class BasicCog(Cog, name="Basic WoD Commands"):
     @option("pool", description="The dice pool. May be a number or trait + attribute equation")
     @options.promoted_choice("difficulty", "The roll's difficulty", start=2, end=10, first=6)
     @option(
+        "use_wp",
+        description="Use WP on the roll. Can also add + WP to your pool",
+        default=False,
+    )
+    @option(
         "specialty",
         description="A specialty to apply to the roll. You may also use trait.spec syntax in pool.",
         required=False,
@@ -31,24 +36,21 @@ class BasicCog(Cog, name="Basic WoD Commands"):
         required=False,
         max_length=300,
     )
-    @option(
-        "use_wp",
-        description="Use WP on the roll. Can also add + WP to your pool",
-        default=False,
-    )
     @options.character("[Optional] The character performing the roll")
     async def roll(
         self,
         ctx: AppCtx,
         pool: str,
         difficulty: int,
+        use_wp: bool,
         specialty: str,
         comment: str,
-        use_wp: bool,
         character: str,
     ):
         """Roll the dice! If you have a character, you can supply traits ("Strength + Brawl")."""
-        await botchcord.roll.roll(ctx, pool, difficulty, specialty, comment, character, use_wp)
+        await botchcord.roll.roll(
+            ctx, pool, difficulty, specialty, use_wp, False, comment, character
+        )
 
 
 def setup(bot: BotchBot):

--- a/src/interface/wod/macros.py
+++ b/src/interface/wod/macros.py
@@ -64,24 +64,24 @@ class MacrosCog(Cog, name="Macro commands"):
         first=6,
         required=False,
     )
-    @option("comment", description="Override the default comment", required=False)
     @option(
         "use_wp",
         description="Override the macro to use WP",
         default=False,
     )
+    @option("comment", description="Override the default comment", required=False)
     @options.character("The character performing the roll")
     async def mroll(
         self,
         ctx: AppCtx,
         name: str,
         difficulty: int,
-        comment: str,
         use_wp: bool,
+        comment: str,
         character: str,
     ):
         """Roll using a macro."""
-        await botchcord.mroll(ctx, name, difficulty, comment, character, use_wp)
+        await botchcord.mroll(ctx, name, difficulty, use_wp, False, comment, character)
 
 
 def setup(bot: BotchBot):

--- a/tests/bcord/test_rolls.py
+++ b/tests/bcord/test_rolls.py
@@ -242,7 +242,7 @@ def test_build_embed_rote_again():
 )
 def test_wod_text_embed_with_character(
     title: str,
-    pool: list[str],
+    pool: list[str | int],
     target: int,
     spec: list[str],
     comment: str,
@@ -288,6 +288,7 @@ def test_wod_text_embed_with_character(
         i += 1
     if roll.uses_traits:
         assert embed.fields[i].name == "Pool"
+        assert roll.pool
         assert embed.fields[i].value == " ".join(map(str, roll.pool))
 
     if comment:
@@ -399,13 +400,13 @@ async def test_roll_command(
     if raises:
         if char is None or char == wod_vampire.name:
             with pytest.raises(errors.RollError):
-                await roll_cmd(ctx, pool, 6, specs, None, char)
+                await roll_cmd(ctx, pool, 6, specs, False, False, None, char)
         else:
             with pytest.raises(errors.CharacterNotFound):
-                await roll_cmd(ctx, pool, 6, specs, None, char)
+                await roll_cmd(ctx, pool, 6, specs, False, False, None, char)
 
     else:
-        await roll_cmd(ctx, pool, 6, specs, None, char)
+        await roll_cmd(ctx, pool, 6, specs, False, False, None, char)
         ctx.respond.assert_called_once_with(embed=ANY)
 
 

--- a/tests/botchcord/macro/test_create.py
+++ b/tests/botchcord/macro/test_create.py
@@ -41,7 +41,7 @@ def test_create_macro(char):
     macro = create_macro(char, "punch", "str+b", 6, "punch a guy")
     assert macro.name == "punch"
     assert macro.pool == ["Strength", "+", "Brawl"]
-    assert macro.difficulty == 6
+    assert macro.target == 6
     assert macro.comment == "punch a guy"
 
 
@@ -90,5 +90,5 @@ async def test_create_cmd(
         assert macro is not None
         assert macro.name == "test"
         assert macro.pool_str == pool
-        assert macro.difficulty == 7
+        assert macro.target == 7
         assert macro.comment is None

--- a/tests/botchcord/macro/test_display.py
+++ b/tests/botchcord/macro/test_display.py
@@ -19,7 +19,7 @@ def macro() -> Macro:
         name="punch",
         pool=["Strength", "+", "Brawl"],
         keys=["Strength", "+", "Brawl"],
-        difficulty=6,
+        target=6,
         rote=False,
         hunt=False,
         comment="Punch a guy",
@@ -40,7 +40,7 @@ def test_create_macro_entry(macro: Macro):
     lines = [
         f"### {macro.name}",
         f"**Pool:** {m(macro.pool_str)}",
-        f"**Difficulty:** {macro.difficulty}",
+        f"**Difficulty:** {macro.target}",
         i(macro.comment),
     ]
     assert entry == "\n".join(lines)

--- a/tests/botchcord/test_mroll.py
+++ b/tests/botchcord/test_mroll.py
@@ -23,7 +23,7 @@ def char(character: Character) -> Character:
 
 async def test_macro_not_found(ctx, char):
     with pytest.raises(errors.NoMatchingCharacter):
-        await mroll(ctx, "fake", None, None, char)
+        await mroll(ctx, "fake", None, False, False, None, char)
 
 
 @pytest.mark.parametrize(
@@ -44,7 +44,7 @@ async def test_mroll(
     macro = char.macros[0]
     diff = diff or macro.target
     comment = comment or macro.comment
-    await mroll(ctx, macro.name, diff, comment, char)  # type: ignore
+    await mroll(ctx, macro.name, diff, False, False, comment, char)  # type: ignore
 
     roll_mock.assert_awaited_once_with(ctx, macro.key_str, diff, None, comment, char, False, False)
 
@@ -53,7 +53,7 @@ async def test_mroll(
 async def test_mroll_no_mock(mock_roll_save: AsyncMock, ctx: AppCtx, char: Character):
     await char.save()
     macro = char.macros[0]
-    await mroll(ctx, macro.name, None, None, char)  # type: ignore
+    await mroll(ctx, macro.name, None, False, False, None, char)  # type: ignore
     ctx.respond.assert_awaited_once_with(embed=ANY)
     mock_roll_save.assert_awaited_once()
 
@@ -63,7 +63,7 @@ async def test_mroll_specs(mock_roll_save: AsyncMock, ctx: AppCtx, char: Charact
     char.add_subtraits("Brawl", ["Grappling"])
     macro = create_macro(char, "specs", "str+b.g", 6, None)
     char.add_macro(macro)
-    await mroll(ctx, macro.name, None, None, char)  # type: ignore
+    await mroll(ctx, macro.name, False, False, None, None, char)  # type: ignore
 
     ctx.respond.assert_awaited_once_with(embed=ANY)
     mock_roll_save.assert_awaited_once()  # This is our proof it rolled
@@ -71,5 +71,5 @@ async def test_mroll_specs(mock_roll_save: AsyncMock, ctx: AppCtx, char: Charact
 
 async def test_mroll_missing_trait(ctx: AppCtx, char: Character):
     char.remove_trait("Brawl")
-    await mroll(ctx, char.macros[0].name, None, None, char)  # type: ignore
+    await mroll(ctx, char.macros[0].name, None, False, False, None, char)  # type: ignore
     ctx.send_error.assert_awaited_once_with("Error", ANY)

--- a/tests/botchcord/test_mroll.py
+++ b/tests/botchcord/test_mroll.py
@@ -46,7 +46,7 @@ async def test_mroll(
     comment = comment or macro.comment
     await mroll(ctx, macro.name, diff, False, False, comment, char)  # type: ignore
 
-    roll_mock.assert_awaited_once_with(ctx, macro.key_str, diff, None, comment, char, False, False)
+    roll_mock.assert_awaited_once_with(ctx, macro.key_str, diff, None, False, False, comment, char)
 
 
 @patch("botchcord.roll.Roll.save", new_callable=AsyncMock)

--- a/tests/botchcord/test_mroll.py
+++ b/tests/botchcord/test_mroll.py
@@ -42,7 +42,7 @@ async def test_mroll(
     comment: str | None,
 ):
     macro = char.macros[0]
-    diff = diff or macro.difficulty
+    diff = diff or macro.target
     comment = comment or macro.comment
     await mroll(ctx, macro.name, diff, comment, char)  # type: ignore
 

--- a/tests/core/characters/test_macros.py
+++ b/tests/core/characters/test_macros.py
@@ -11,7 +11,7 @@ mc = partial(
     Macro,
     pool=["Strength", "+", "Brawl", "-", 1],
     keys=["Strength", "+", "Brawl", "-", 1],
-    difficulty=6,
+    target=6,
     rote=False,
     hunt=False,
     comment=None,


### PR DESCRIPTION
This renames a field in the Macro subdocument and reorders the arguments for mroll and roll (both game lines).