### PR TITLE
Feat: add auto-successes

### DIFF
--- a/src/botchcord/mroll.py
+++ b/src/botchcord/mroll.py
@@ -16,6 +16,8 @@ async def mroll(
     rote_override: bool,
     comment_override: str | None,
     character: str | None,
+    *,
+    autos=0,
 ):
     """Perform a macro roll.
 
@@ -32,7 +34,17 @@ async def mroll(
     rote = rote_override or macro.rote
 
     try:
-        await botchcord.roll.roll(ctx, macro.key_str, difficulty, None, use_wp, rote, comment, char)
+        await botchcord.roll.roll(
+            ctx,
+            macro.key_str,
+            difficulty,
+            None,
+            use_wp,
+            rote,
+            comment,
+            char,
+            autos=autos,
+        )
     except errors.RollError:
         await ctx.send_error(
             "Error",

--- a/src/botchcord/roll.py
+++ b/src/botchcord/roll.py
@@ -58,6 +58,7 @@ async def roll(
     comment: Optional[str],
     character: Optional[str | Character],
     *,
+    autos=0,
     owner: discord.Member | None = None,
 ):
     """Perform and display the specified roll. The roll is saved to the database."""
@@ -78,7 +79,7 @@ async def roll(
             raise errors.RollError(f"No characters able to roll `{pool}`.")
 
     rp.parse()
-    roll = Roll.from_parser(rp, ctx.guild.id, ctx.user.id, target, GAME_LINE, rote).roll()
+    roll = Roll.from_parser(rp, ctx.guild.id, ctx.user.id, target, GAME_LINE, rote, autos).roll()
 
     extra_specs = []
     if specialties:
@@ -150,6 +151,9 @@ def build_embed(
     else:
         dice_description = textify_dice(roll)
 
+    if roll.autos:
+        auto_str = "auto" if roll.autos == 1 else "autos"
+        dice_description += f" *+ {roll.autos} {auto_str}*"
     if roll.line == GameLine.WOD and roll.wp:
         dice_description += " *+ WP*"
 

--- a/src/core/rolls/roll.py
+++ b/src/core/rolls/roll.py
@@ -191,6 +191,7 @@ class Roll(Document):
         target: int,
         line: GameLine | str | None = GAME_LINE,
         rote=False,
+        autos=0,
     ):
         """Create a roll from a RollParser and a target number."""
         if not line:
@@ -210,6 +211,7 @@ class Roll(Document):
             specialties=p.specialties,
             pool=p.pool,
             syntax=p.raw_syntax,
+            autos=autos,
             character=p.character,
         )
 

--- a/src/interface/cofd/basic.py
+++ b/src/interface/cofd/basic.py
@@ -31,6 +31,7 @@ class BasicCog(Cog, name="Basic"):
         required=False,
     )
     @option("rote", description="Whether to apply the Rote quality", default=False)
+    @option("autos", description="Add automatic successes", choices=list(range(11)), default=0)
     @option(
         "comment",
         description="A comment to show alongside the roll",
@@ -46,6 +47,7 @@ class BasicCog(Cog, name="Basic"):
         use_wp: bool,
         again: int,
         rote: bool,
+        autos: int,
         specialty: str,
         comment: str,
         character: str,
@@ -53,7 +55,7 @@ class BasicCog(Cog, name="Basic"):
     ):
         """Roll the dice! If you have a character, `pool` can be traits (e.g. `Strength + Brawl`)."""
         await botchcord.roll.roll(
-            ctx, pool, again, specialty, use_wp, rote, comment, character, owner=owner
+            ctx, pool, again, specialty, use_wp, rote, comment, character, autos=autos, owner=owner
         )
 
     @slash_command()

--- a/src/interface/cofd/macros.py
+++ b/src/interface/cofd/macros.py
@@ -77,6 +77,7 @@ class MacrosCog(Cog, name="Macros"):
         description="Override the macro to use WP",
         default=False,
     )
+    @option("autos", description="Add automatic successes", choices=list(range(11)), default=0)
     @option("comment", description="Override the default comment", required=False)
     @options.character("The character performing the roll")
     async def mroll(
@@ -86,11 +87,12 @@ class MacrosCog(Cog, name="Macros"):
         again: int,
         rote: bool,
         use_wp: bool,
+        autos: int,
         comment: str,
         character: str,
     ):
         """Roll using a macro."""
-        await botchcord.mroll(ctx, name, again, use_wp, rote, comment, character)
+        await botchcord.mroll(ctx, name, again, use_wp, rote, comment, character, autos=autos)
 
 
 def setup(bot: BotchBot):

--- a/src/interface/wod/basic.py
+++ b/src/interface/wod/basic.py
@@ -31,6 +31,7 @@ class BasicCog(Cog, name="Basic"):
         description="A specialty to apply to the roll. You may also use trait.spec syntax in pool.",
         required=False,
     )
+    @option("autos", description="Add automatic successes", choices=list(range(11)), default=0)
     @option(
         "comment",
         description="A comment to show alongside the roll",
@@ -46,6 +47,7 @@ class BasicCog(Cog, name="Basic"):
         difficulty: int,
         use_wp: bool,
         specialty: str,
+        autos: int,
         comment: str,
         character: str,
         owner: discord.Member,
@@ -60,6 +62,7 @@ class BasicCog(Cog, name="Basic"):
             False,
             comment,
             character,
+            autos=autos,
             owner=owner,
         )
 

--- a/src/interface/wod/macros.py
+++ b/src/interface/wod/macros.py
@@ -77,6 +77,7 @@ class MacrosCog(Cog, name="Macros"):
         description="Override the macro to use WP",
         default=False,
     )
+    @option("autos", description="Add automatic successes", choices=list(range(11)), default=0)
     @option("comment", description="Override the default comment", required=False)
     @options.character("The character performing the roll")
     async def mroll(
@@ -84,13 +85,14 @@ class MacrosCog(Cog, name="Macros"):
         ctx: AppCtx,
         name: str,
         difficulty: int,
+        autos: int,
         use_wp: bool,
         comment: str,
         character: str,
     ):
         """Roll using a macro. Allows for overriding the difficulty, comment,\
         and using Willpower."""
-        await botchcord.mroll(ctx, name, difficulty, use_wp, False, comment, character)
+        await botchcord.mroll(ctx, name, difficulty, use_wp, False, comment, character, autos=autos)
 
 
 def setup(bot: BotchBot):

--- a/tests/botchcord/test_mroll.py
+++ b/tests/botchcord/test_mroll.py
@@ -44,9 +44,11 @@ async def test_mroll(
     macro = char.macros[0]
     diff = diff or macro.target
     comment = comment or macro.comment
-    await mroll(ctx, macro.name, diff, False, False, comment, char)  # type: ignore
+    await mroll(ctx, macro.name, diff, False, False, comment, char, autos=1)  # type: ignore
 
-    roll_mock.assert_awaited_once_with(ctx, macro.key_str, diff, None, False, False, comment, char)
+    roll_mock.assert_awaited_once_with(
+        ctx, macro.key_str, diff, None, False, False, comment, char, autos=1
+    )
 
 
 @patch("botchcord.roll.Roll.save", new_callable=AsyncMock)

--- a/tests/botchcord/test_rolls.py
+++ b/tests/botchcord/test_rolls.py
@@ -218,6 +218,24 @@ def test_wod_roll_embed_with_willpower(
         assert not embed.description.endswith(" *+ WP*")
 
 
+@pytest.mark.parametrize(
+    "autos",
+    [0, 1, 2],
+)
+def test_roll_embed_with_autos(autos: int, ctx: AppCtx):
+    rp = RollParser("5", None).parse()
+    roll = Roll.from_parser(rp, 0, 0, 6, autos=autos)
+    embed = build_embed(ctx, roll, None, None, False)
+
+    assert embed.description is not None
+    if autos == 0:
+        assert "auto" not in embed.description
+    elif autos == 1:
+        assert embed.description.endswith(f" *+ {autos} auto*")
+    else:
+        assert embed.description.endswith(f" *+ {autos} autos*")
+
+
 def test_build_embed_author_no_char():
     rp = RollParser("6", None).parse()
     roll = Roll.from_parser(rp, 0, 0, 6, GameLine.WOD)


### PR DESCRIPTION
Adds an `autos` parameter to `/roll` and `/mroll` (both WoD and CofD).