### PR TITLE
FIX: Mummy display, adjustment

### DIFF
--- a/src/botch/botchcord/character/adjust.py
+++ b/src/botch/botchcord/character/adjust.py
@@ -469,9 +469,15 @@ class MummyPillarAdjuster(Adjuster):
         bad = ButtonStyle.danger
         good = ButtonStyle.success
 
-        for i, pillar in enumerate(self.pillars):
-            self.add_stepper(i + 1, f"{pillar.value} (Permanent)", dec_color=bad, inc_color=good)
-            self.add_stepper(i + 2, f"{pillar.value} (Current)", dec_color=bad, inc_color=good)
+        row_offset = 0
+        for pillar in self.pillars:
+            self.add_stepper(
+                row_offset + 1, f"{pillar.value} (Permanent)", dec_color=bad, inc_color=good
+            )
+            self.add_stepper(
+                row_offset + 2, f"{pillar.value} (Current)", dec_color=bad, inc_color=good
+            )
+            row_offset += 2
 
     def _update_buttons(self):
         pillar = self.character.get_pillar(self.pillars[0])

--- a/src/botch/botchcord/character/adjust.py
+++ b/src/botch/botchcord/character/adjust.py
@@ -136,6 +136,9 @@ class Toggler(View):
         elif isinstance(self.character, cofd.Vampire):
             fields.append(DisplayField.VITAE)
             fields.append(DisplayField.BLOOD_POTENCY)
+        elif isinstance(self.character, cofd.Mummy):
+            fields.append(DisplayField.SEKHEM)
+            fields.append(DisplayField.PILLARS)
         return build_embed(self.ctx.bot, self.character, use_emojis, fields=tuple(fields))
 
     async def on_timeout(self):

--- a/src/botch/core/characters/cofd/base.py
+++ b/src/botch/core/characters/cofd/base.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 from pydantic import BaseModel, Field, model_validator
 
 from botch.core.characters.base import Character, GameLine, Splat, Trait
+from botch.errors import TraitAlreadyExists
 from botch.utils import max_vtr_vitae
 
 
@@ -174,3 +175,27 @@ class Mummy(Mortal):
             if pillar.name.lower() == name.lower():
                 return pillar
         raise ValueError("Unknown Pillar")
+
+    def add_trait(
+        self,
+        name: str,
+        rating: int,
+        category=Trait.Category.CUSTOM,
+        subcategory=Trait.Subcategory.BLANK,
+    ) -> Trait:
+        """Add a new trait.
+        Args:
+            name (str): The new Trait's name
+            rating (int): The new Trait's rating
+            category (enum): The new Trait's category
+
+        The Traits list is automatically kept sorted.
+
+        Returns a copy of the new Trait, if created.
+        Raises TraitAlreadyExists if a Trait by that name already exists.
+        Raises TraitAlreadyExists if the Trait is a Pillar."""
+        titled = name.title()
+        if titled in Mummy.Pillars:
+            raise TraitAlreadyExists(f"**{titled}** is a Pillar! Use `/character adjust` instead.")
+
+        return super().add_trait(name, rating, category, subcategory)

--- a/src/botch/core/characters/wod/__init__.py
+++ b/src/botch/core/characters/wod/__init__.py
@@ -1,6 +1,6 @@
 """World of Darkness characters submodule."""
 
-from botch.core.characters.wod.mortal import Ghoul, Mortal, gen_virtues
+from botch.core.characters.wod.mortal import Ghoul, Mortal, Virtue, gen_virtues
 from botch.core.characters.wod.vampire import Vampire
 
-__all__ = ("Ghoul", "Mortal", "Vampire", "gen_virtues")
+__all__ = ("Ghoul", "Mortal", "Vampire", "Virtue", "gen_virtues")


### PR DESCRIPTION
Adds the following Mummy fixes:

* `/character display`: Now shows Sekhem and Pillars
* `/character adjust`: Now displays Sekhem and Pillars
* `/character adjust`: Fixed Pillars adjustment
* `/traits assign`: Gives an error if the user tries to assign Pillars

Also adds a missing import causing CI to fail that somehow didn't get squashed into master.