### PR TITLE
Beat: Add advanced actions

### DIFF
--- a/src/botch/botchcord/macro/create.py
+++ b/src/botch/botchcord/macro/create.py
@@ -17,6 +17,8 @@ async def create(
     diff: int,
     comment: str | None,
     rote=False,
+    blessed=False,
+    blighted=False,
 ):
     """Create a macro and add it to the character."""
     # can_use_macro() is too complex for the @haven decorator
@@ -25,7 +27,7 @@ async def create(
             ctx, GAME_LINE, None, character, None, filter=lambda c: can_use_macro(c, pool)
         )
         char = await haven.get_match()
-        macro = create_macro(char, name, pool, diff, comment, rote)
+        macro = create_macro(char, name, pool, diff, comment, rote, blessed, blighted)
         char.add_macro(macro)
 
         embed = build_embed(ctx.bot, char, macro)
@@ -63,6 +65,8 @@ def create_macro(
     diff: int,
     comment: str | None,
     rote=False,
+    blessed=False,
+    blighted=False,
 ) -> Macro:
     """Create a macro."""
     rpp = RollParser(pool, char).parse()
@@ -73,6 +77,8 @@ def create_macro(
         keys=rpk.pool,
         target=diff,
         rote=rote,
+        blessed=blessed,
+        blighted=blighted,
         hunt=False,
         comment=comment,
     )

--- a/src/botch/botchcord/macro/display.py
+++ b/src/botch/botchcord/macro/display.py
@@ -53,6 +53,14 @@ def create_macro_entry(macro: Macro) -> str:
     ]
     if is_cofd:
         lines.append(f"**Rote:** {'Yes' if macro.rote else 'No'}")
+
+        if macro.blessed:
+            advanced = "Blessed"
+        elif macro.blighted:
+            advanced = "Blighted"
+        else:
+            advanced = "No"
+        lines.append(f"**Advanced:** {advanced}")
     if macro.comment:
         lines.append(i(macro.comment))
 

--- a/src/botch/botchcord/mroll.py
+++ b/src/botch/botchcord/mroll.py
@@ -16,6 +16,8 @@ async def mroll(
     character: str | None,
     *,
     autos=0,
+    blessed_override=False,
+    blighted_override=False,
 ):
     """Perform a macro roll.
 
@@ -30,6 +32,8 @@ async def mroll(
     difficulty = target_override or macro.target
     comment = comment_override or macro.comment
     rote = rote_override or macro.rote
+    blessed = blessed_override or macro.blessed
+    blighted = blighted_override or macro.blighted
 
     try:
         await botchcord.roll.roll(
@@ -42,6 +46,8 @@ async def mroll(
             comment,
             char,
             autos=autos,
+            blessed=blessed,
+            blighted=blighted,
         )
     except errors.RollError:
         await ctx.send_error(

--- a/src/botch/botchcord/roll.py
+++ b/src/botch/botchcord/roll.py
@@ -56,6 +56,8 @@ async def roll(
     character: Optional[str | Character],
     *,
     autos=0,
+    blessed=False,
+    blighted=False,
     owner: discord.Member | None = None,
 ):
     """Perform and display the specified roll. The roll is saved to the database."""
@@ -76,7 +78,17 @@ async def roll(
             raise errors.RollError(f"No characters able to roll `{pool}`.")
 
     rp.parse()
-    roll = Roll.from_parser(rp, ctx.guild.id, ctx.user.id, target, GAME_LINE, rote, autos).roll()
+    roll = Roll.from_parser(
+        rp,
+        ctx.guild.id,
+        ctx.user.id,
+        target,
+        GAME_LINE,
+        rote,
+        autos,
+        blessed,
+        blighted,
+    ).roll()
 
     extra_specs = []
     if specialties:
@@ -135,6 +147,10 @@ def build_embed(
         author_name = ctx.author.display_name
     if not icon:
         icon = botchcord.get_avatar(ctx.author)
+    if roll.blessed:
+        author_name += " • Blessed"
+    elif roll.blighted:
+        author_name += " • Blighted"
     if roll.rote:
         author_name += " • Rote"
     if roll.again < 10:

--- a/src/botch/core/characters/base.py
+++ b/src/botch/core/characters/base.py
@@ -106,6 +106,8 @@ class Macro(BaseModel):
     keys: list[str | int]
     target: int = Field(ge=2, le=10)
     rote: bool
+    blessed: bool = False
+    blighted: bool = False
     hunt: bool
     comment: Optional[str]
 

--- a/src/botch/core/rolls/roll.py
+++ b/src/botch/core/rolls/roll.py
@@ -213,6 +213,8 @@ class Roll(Document):
         line: GameLine | str | None = GAME_LINE,
         rote=False,
         autos=0,
+        blessed=False,
+        blighted=False,
     ):
         """Create a roll from a RollParser and a target number."""
         if not line:
@@ -234,6 +236,8 @@ class Roll(Document):
             syntax=p.raw_syntax,
             autos=autos,
             character=p.character,
+            blessed=blessed,
+            blighted=blighted,
         )
 
     @staticmethod

--- a/src/botch/core/rolls/roll.py
+++ b/src/botch/core/rolls/roll.py
@@ -197,7 +197,7 @@ class Roll(Document):
                 if self.wp:
                     explosions -= 3
                 if explosions > 0:
-                    readout += f" *+ [{explosions}]*"
+                    readout += f" *+ {explosions}X*"
                 if self.wp:
                     readout += " *+ WP*"
 

--- a/src/botch/interface/cofd/basic.py
+++ b/src/botch/interface/cofd/basic.py
@@ -29,6 +29,12 @@ class BasicCog(BotchCog, name="Basic"):
     @option("again", description="The number at which dice explode", choices=[10, 9, 8], default=10)
     @option("rote", description="Whether to apply the Rote quality", default=False)
     @option(
+        "advanced",
+        description="Whether it is a Blessed or Blighted Action",
+        choices=["Blessed", "Blighted"],
+        required=False,
+    )
+    @option(
         "specialty",
         description="A specialty to apply to the roll. You may also use trait.spec syntax in pool.",
         required=False,
@@ -49,6 +55,7 @@ class BasicCog(BotchCog, name="Basic"):
         use_wp: bool,
         again: int,
         rote: bool,
+        advanced: str,
         specialty: str,
         autos: int,
         comment: str,
@@ -56,8 +63,26 @@ class BasicCog(BotchCog, name="Basic"):
         owner: discord.Member,
     ):
         """Roll the dice! If you have a character, `pool` can be traits (e.g. `Strength + Brawl`)."""
+        blessed = False
+        blighted = False
+        if advanced == "Blessed":
+            blessed = True
+        elif advanced == "Blighted":
+            blighted = True
+
         await botchcord.roll.roll(
-            ctx, pool, again, specialty, use_wp, rote, comment, character, autos=autos, owner=owner
+            ctx,
+            pool,
+            again,
+            specialty,
+            use_wp,
+            rote,
+            comment,
+            character,
+            autos=autos,
+            blessed=blessed,
+            blighted=blighted,
+            owner=owner,
         )
 
     @slash_command()

--- a/src/botch/interface/cofd/macros.py
+++ b/src/botch/interface/cofd/macros.py
@@ -37,6 +37,12 @@ class MacrosCog(BotchCog, name="Macros"):
     @option("pool", description="The dice pool for the macro to use")
     @option("again", description="The number to explode at", choices=[10, 9, 8], default=10)
     @option("rote", description="Whether to always apply the Rote quality", default=False)
+    @option(
+        "advanced",
+        description="Whether to make it a Blessed or Blighted Action",
+        choices=["Blessed", "Blighted"],
+        required=False,
+    )
     @option("comment", description="A comment to apply by default when rolling", required=False)
     @options.character("The character receiving the macro")
     async def macro_create(
@@ -46,11 +52,22 @@ class MacrosCog(BotchCog, name="Macros"):
         pool: str,
         again: int,
         rote: bool,
+        advanced: str,
         comment: str,
         character: str,
     ):
         """Create a macro."""
-        await botchcord.macro.create(ctx, character, name, pool, again, comment, rote)
+        await botchcord.macro.create(
+            ctx,
+            character,
+            name,
+            pool,
+            again,
+            comment,
+            rote,
+            advanced == "Blessed",
+            advanced == "Blighted",
+        )
 
     @macro.command(name="list")
     @options.character("The character whose macros to display")
@@ -79,6 +96,12 @@ class MacrosCog(BotchCog, name="Macros"):
         description="Override the macro to use WP",
         default=False,
     )
+    @option(
+        "advanced",
+        description="Override Blessed/Blighted quality",
+        choices=["Blessed", "Blighted"],
+        required=False,
+    )
     @option("autos", description="Add automatic successes", choices=list(range(11)), default=0)
     @option("comment", description="Override the default comment", required=False)
     @options.character("The character performing the roll")
@@ -88,13 +111,25 @@ class MacrosCog(BotchCog, name="Macros"):
         name: str,
         again: int,
         rote: bool,
+        advanced: str,
         use_wp: bool,
         autos: int,
         comment: str,
         character: str,
     ):
         """Roll using a macro."""
-        await botchcord.mroll(ctx, name, again, use_wp, rote, comment, character, autos=autos)
+        await botchcord.mroll(
+            ctx,
+            name,
+            again,
+            use_wp,
+            rote,
+            comment,
+            character,
+            autos=autos,
+            blessed_override=advanced == "Blessed",
+            blighted_override=advanced == "Blighted",
+        )
 
 
 def setup(bot: BotchBot):

--- a/tests/botchcord/test_mroll.py
+++ b/tests/botchcord/test_mroll.py
@@ -47,7 +47,17 @@ async def test_mroll(
     await mroll(ctx, macro.name, diff, False, False, comment, char, autos=1)  # type: ignore
 
     roll_mock.assert_awaited_once_with(
-        ctx, macro.key_str, diff, None, False, False, comment, char, autos=1
+        ctx,
+        macro.key_str,
+        diff,
+        None,
+        False,
+        False,
+        comment,
+        char,
+        autos=1,
+        blessed=False,
+        blighted=False,
     )
 
 

--- a/tests/botchcord/test_rolls.py
+++ b/tests/botchcord/test_rolls.py
@@ -9,11 +9,20 @@ from cachetools import TTLCache
 
 from botch import core, errors
 from botch.bot import AppCtx
-from botch.botchcord.roll import DICE_CAP, DICE_CAP_MESSAGE, Color, add_wp, build_embed
+from botch.botchcord.roll import (
+    DICE_CAP,
+    DICE_CAP_MESSAGE,
+    Color,
+    add_wp,
+    build_embed,
+    embed_color,
+    embed_title,
+    emoji_name,
+    emojify_dice,
+    textify_dice,
+)
 from botch.botchcord.roll import chance as chance_cmd
-from botch.botchcord.roll import embed_color, embed_title, emoji_name, emojify_dice
 from botch.botchcord.roll import roll as roll_cmd
-from botch.botchcord.roll import textify_dice
 from botch.core.characters import Character, Damage, GameLine, Splat, Trait
 from botch.core.rolls import Roll
 from botch.core.rolls.parse import RollParser
@@ -263,6 +272,28 @@ def test_build_embed_rote_again():
     embed = build_embed(ctx, roll, None, None, True)
     assert embed.author is not None
     assert embed.author.name == "Jimmy Maxwell • Rote • 8-again"
+
+
+@pytest.mark.parametrize(
+    "blessed,blighted",
+    [
+        (True, False),
+        (False, True),
+    ],
+)
+def test_build_embed_blessed_blighted(blessed: bool, blighted: bool):
+    rp = RollParser("6", None).parse()
+    roll = Roll.from_parser(rp, 0, 0, 8, GameLine.COFD, True, blessed=blessed, blighted=blighted)
+
+    ctx = Mock()
+    ctx.author = Mock(spec=discord.User)  # Make it a User to finish testing get_avatar()
+    ctx.author.display_name = "Jimmy Maxwell"
+    ctx.author.display_avatar = "https://example.com/icon.png"
+
+    action = "Blessed" if blessed else "Blighted"
+    embed = build_embed(ctx, roll, None, None, True)
+    assert embed.author is not None
+    assert embed.author.name == f"Jimmy Maxwell • {action} • Rote • 8-again"
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_cofd_rolls.py
+++ b/tests/core/test_cofd_rolls.py
@@ -141,10 +141,10 @@ def test_selects_longer_roll(mock_d10: Mock, roll: Roll):
         ([5, 5, 5, 5, 5, 5, 5, 5], True, False, "5 *+ WP*"),
         ([5, 5, 5, 5, 5, 5, 5, 5, 5], True, True, "6 *+ WP*"),
         ([5, 5, 5, 5, 5, 5], False, True, "6"),
-        ([5, 5, 5, 5, 10, 5], False, False, "5 *+ [1]*"),
-        ([5, 5, 5, 5, 10, 5, 5, 10, 5, 5], True, False, "5 *+ [2]* *+ WP*"),
-        ([5, 5, 5, 5, 10, 5, 5], False, True, "6 *+ [1]*"),
-        ([5, 5, 5, 5, 10, 5, 5, 5, 5, 5], True, True, "6 *+ [1]* *+ WP*"),
+        ([5, 5, 5, 5, 10, 5], False, False, "5 *+ 1X*"),
+        ([5, 5, 5, 5, 10, 5, 5, 10, 5, 5], True, False, "5 *+ 2X* *+ WP*"),
+        ([5, 5, 5, 5, 10, 5, 5], False, True, "6 *+ 1X*"),
+        ([5, 5, 5, 5, 10, 5, 5, 5, 5, 5], True, True, "6 *+ 1X* *+ WP*"),
     ],
 )
 def test_dice_readout(

--- a/tests/core/test_cofd_rolls.py
+++ b/tests/core/test_cofd_rolls.py
@@ -1,0 +1,180 @@
+"""CofD roll tests."""
+
+from typing import Generator
+from unittest.mock import Mock, patch
+
+import pytest
+
+from botch.core.characters import GameLine
+from botch.core.rolls.roll import Roll
+
+
+@pytest.fixture
+def mock_d10() -> Generator[Mock, None, None]:
+    with patch("botch.core.rolls.roll.d10") as mock:
+        yield mock
+
+
+@pytest.fixture
+def roll() -> Roll:
+    return Roll(
+        line=GameLine.COFD,
+        guild=0,
+        user=0,
+        num_dice=5,
+        target=10,
+    )
+
+
+@pytest.mark.parametrize(
+    "dice,expected,success_str",
+    [
+        ([5, 5, 5, 5, 5], 0, "Failure"),
+        ([8, 5, 5, 5, 5], 1, "Success"),
+        ([8, 5, 5, 8, 8], 3, "Success"),
+        ([8, 8, 8, 8, 8], 5, "Exceptional!"),
+    ],
+)
+def test_plain_success_count(
+    mock_d10: Mock,
+    roll: Roll,
+    dice: list[int],
+    expected: int,
+    success_str: str,
+):
+    mock_d10.side_effect = dice
+
+    roll.roll()
+    assert roll.successes == expected
+    assert roll.success_str == success_str
+
+
+@pytest.mark.parametrize(
+    "target, dice,expected",
+    [
+        (10, [5, 5, 5, 5, 5], 5),
+        (10, [10, 5, 5, 5, 5, 5], 6),
+        (10, [10, 5, 5, 5, 5, 10, 5], 7),
+        (10, [10, 5, 5, 8, 9, 10, 10, 5], 8),
+        (9, [5, 5, 5, 9, 8, 5], 6),
+        (9, [5, 5, 10, 9, 8, 5, 5], 7),
+        (8, [5, 5, 5, 7, 8, 5], 6),
+        (8, [5, 5, 5, 9, 8, 5, 7], 7),
+        (8, [5, 5, 5, 9, 8, 5, 10, 7], 8),
+    ],
+)
+def test_explosions(mock_d10: Mock, roll: Roll, target: int, dice: list[str], expected: int):
+    mock_d10.side_effect = dice
+    roll.target = target
+    roll.roll()
+
+    assert len(roll.dice) == expected
+
+
+def test_blessed(mock_d10: Mock, roll: Roll):
+    mock_d10.side_effect = [5] * 5 + [8] * 5
+    roll.blessed = True
+    roll.roll()
+
+    assert roll.dice == [8] * 5
+
+
+def test_blighted(mock_d10: Mock, roll: Roll):
+    mock_d10.side_effect = [8] * 5 + [5] * 5
+    roll.blighted = True
+    roll.roll()
+
+    assert roll.dice == [5] * 5
+
+
+def test_rote(mock_d10: Mock, roll: Roll):
+    mock_d10.side_effect = [8, 5, 5, 5, 5] + [6] * 4
+    roll.rote = True
+    roll.roll()
+
+    assert roll.dice == [8, 6, 6, 6, 6]
+
+
+def test_rote_explodes(mock_d10: Mock, roll: Roll):
+    second = [10, 6, 6, 6, 6, 6]
+    mock_d10.side_effect = [5] * 5 + second
+    roll.rote = True
+    roll.roll()
+
+    assert roll.dice == second
+
+
+def test_blessed_rote(mock_d10: Mock, roll: Roll):
+    mock_d10.side_effect = [5] * 5 + [6] * 5 + [8] * 5
+    roll.blessed = True
+    roll.rote = True
+    roll.roll()
+
+    assert roll.dice == [8] * 5
+    assert roll.successes == 5
+
+
+def test_complex_rote(mock_d10: Mock, roll: Roll):
+    mock_d10.side_effect = [10, 8, 5, 5, 8, 10, 7, 10, 8, 7, 10, 8, 5, 5, 10, 8, 6]
+    roll.rote = True
+    roll.wp = True
+    roll.roll()
+
+    assert roll.dice == [10, 8, 8, 10, 10, 8, 10, 8, 5, 5, 10, 8, 6]
+    assert roll.dice_readout == "5 *+ 5X* *+ WP*"
+
+
+def test_selects_longer_roll(mock_d10: Mock, roll: Roll):
+    first = [8, 5, 5, 5, 5]
+    second = [10, 6, 6, 6, 6, 6]
+    mock_d10.side_effect = first + second
+    roll.blessed = True
+    roll.roll()
+
+    assert roll.dice == second
+
+
+@pytest.mark.parametrize(
+    "dice,wp,specs,expected",
+    [
+        ([5, 5, 5, 5, 5], False, False, "5"),
+        ([5, 5, 5, 5, 5, 5, 5, 5], True, False, "5 *+ WP*"),
+        ([5, 5, 5, 5, 5, 5, 5, 5, 5], True, True, "6 *+ WP*"),
+        ([5, 5, 5, 5, 5, 5], False, True, "6"),
+        ([5, 5, 5, 5, 10, 5], False, False, "5 *+ [1]*"),
+        ([5, 5, 5, 5, 10, 5, 5, 10, 5, 5], True, False, "5 *+ [2]* *+ WP*"),
+        ([5, 5, 5, 5, 10, 5, 5], False, True, "6 *+ [1]*"),
+        ([5, 5, 5, 5, 10, 5, 5, 5, 5, 5], True, True, "6 *+ [1]* *+ WP*"),
+    ],
+)
+def test_dice_readout(
+    mock_d10: Mock,
+    roll: Roll,
+    dice: list[int],
+    wp: bool,
+    specs: bool,
+    expected: str,
+):
+    mock_d10.side_effect = dice
+    roll.wp = wp
+    if specs:
+        roll.add_specs(["spec"])
+    roll.roll()
+
+    assert roll.dice_readout == expected
+
+
+def test_readout_8_again(mock_d10: Mock, roll: Roll):
+    dice = [10, 5, 5, 5, 9, 5, 5, 5, 8, 5, 5, 5]
+    mock_d10.side_effect = dice
+    roll.target = 8
+    roll.wp = True
+    roll.add_specs(["spec"])
+    roll.roll()
+
+    assert roll.dice == dice
+    assert roll.dice_readout == "6 *+ 3X* *+ WP*"
+
+
+def test_cofd_successes(roll: Roll):
+    assert roll._cofd_successes([1, 2, 8]) == 1

--- a/tests/rolls/test_rolls.py
+++ b/tests/rolls/test_rolls.py
@@ -61,13 +61,13 @@ def test_cofd_explosions():
         (GameLine.WOD, [5] * 5, ["a"], False, "5"),
         (GameLine.WOD, [5] * 5, None, True, "5"),
         (GameLine.COFD, [5] * 5, None, False, "5"),
-        (GameLine.COFD, [5] * 6, None, False, "5 *+ [1]*"),
-        (GameLine.COFD, [5] * 9, None, True, "5 *+ [1]* *+ WP*"),
+        (GameLine.COFD, [5] * 6, None, False, "5 *+ 1X*"),
+        (GameLine.COFD, [5] * 9, None, True, "5 *+ 1X* *+ WP*"),
         (GameLine.COFD, [5] * 8, None, True, "5 *+ WP*"),
         (GameLine.COFD, [5] * 6, ["a"], False, "6"),
-        (GameLine.COFD, [5] * 7, ["a"], False, "6 *+ [1]*"),
+        (GameLine.COFD, [5] * 7, ["a"], False, "6 *+ 1X*"),
         (GameLine.COFD, [5] * 9, ["a"], True, "6 *+ WP*"),
-        (GameLine.COFD, [5] * 10, ["a"], True, "6 *+ [1]* *+ WP*"),
+        (GameLine.COFD, [5] * 10, ["a"], True, "6 *+ 1X* *+ WP*"),
     ],
 )
 def test_dice_readout(


### PR DESCRIPTION
Adds advanced actions for CofD rolls and macros:

* **Blessed:** Roll twice and keep the greater
* **Blighted:** Roll twice and keep the lesser

If the roll is also Rote, that quality will be applied after the above choice. If the two rolls create an equal number of successes, then the larger of the two (in case of explosions) will be kept, allowing for the maximum possible number of dice if the roll is Rote.

Also changes the CofD dice readout from `[N]` for explosions to `nX`, which is hopefully clearer.

**Example:**

```
8 + 2X + WP
```